### PR TITLE
fixed tcp line

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ pdisk=$(df -BM | grep '^/dev/' | grep -v '/boot$' | awk '{ut += $3} {ft+= $2} EN
 cpul=$(top -bn1 | grep '^%Cpu' | cut -c 9- | xargs | awk '{printf("%.1f%%"), $1 + $3}')
 lb=$(who -b | awk '$1 == "system" {print $3 " " $4}')
 lvmu=$(if [ $(lsblk | grep "lvm" | wc -l) -eq 0 ]; then echo no; else echo yes; fi)
-ctcp=$(ss -neopt state established | wc -l)
+ctcp=$(ss -Ht state established | wc -l)
 ulog=$(users | wc -w)
 ip=$(hostname -I)
 mac=$(ip link show | grep "ether" | awk '{print $2}')


### PR DESCRIPTION
Changed the -neopt flags in the TCP connection line to -Ht.
The old version would show one TCP too many because it would count the header line as an extra TCP connection.