### PR TITLE
fix logic of showing lvm use in monitoring.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ udisk=$(df -BM | grep '^/dev/' | grep -v '/boot$' | awk '{ut += $3} END {print u
 pdisk=$(df -BM | grep '^/dev/' | grep -v '/boot$' | awk '{ut += $3} {ft+= $2} END {printf("%d"), ut/ft*100}')
 cpul=$(top -bn1 | grep '^%Cpu' | cut -c 9- | xargs | awk '{printf("%.1f%%"), $1 + $3}')
 lb=$(who -b | awk '$1 == "system" {print $3 " " $4}')
-lvmu=$(if [ $(lsblk | grep "lvm" | wc -l) -eq 0 ]; then echo no; else echo yes; fi)
+lvmu=$(if [ $(lsblk | awk '{print $6}' | grep "lvm" | wc -l) -eq 0 ]; then echo no; else echo yes; fi)
 ctcp=$(ss -Ht state established | wc -l)
 ulog=$(users | wc -w)
 ip=$(hostname -I)


### PR DESCRIPTION
changed to filer `lsblk` output by TYPE field is `lvm`